### PR TITLE
✨ add Carthage, libraries and build directory to ignore list

### DIFF
--- a/unused.rb
+++ b/unused.rb
@@ -124,8 +124,15 @@ class Unused
 
     }
 
-
-    items = items.select { |f| !f.file.start_with?("Pods/") && !f.file.end_with?("Tests.swift") && !f.file.end_with?("Spec.swift") && !f.file.include?("Tests/") }
+    items = items.select { |f|
+        !f.file.start_with?("Pods/") &&
+        !f.file.end_with?("Tests.swift") &&
+        !f.file.end_with?("Spec.swift") &&
+        !f.file.include?("Tests/") &&
+        !f.file.start_with?("Carthage/") &&
+        !f.file.start_with?("build/") &&
+        !f.file.start_with?("libraries/")
+    }
     if items.length > 0
       if ARGV[0] == "xcode"
         $stderr.puts "#{items.map { |e| e.to_xcode }.join("\n")}"


### PR DESCRIPTION
I added the directories to ignore to the same spot that Pods was being ignored. 

I don't know a lot about ruby, but this might make sense to filter out earlier, in the find, with the `dir.glob`

I also tried to pass this directories in as arguments, but also couldn't figure out that yet