### PR TITLE
Skip fastlane directory

### DIFF
--- a/unused.rb
+++ b/unused.rb
@@ -111,6 +111,7 @@ class Unused
     if not should_skip_predefined_ignores
       regexps += [
        "^Pods/",
+       "fastlane/",
        "Tests.swift$",
        "Spec.swift$",
        "Tests/"


### PR DESCRIPTION
I want to add the `fastlane` directory to `should_skip_predefined_ignores`.

[Fastlane.swift](https://docs.fastlane.tools/getting-started/ios/fastlane-swift/) generates a large number of swift files under the `fastlane` directory.

<img width="581" alt="スクリーンショット 2019-07-31 0 13 34" src="https://user-images.githubusercontent.com/519695/62141785-1db55e80-b328-11e9-9e9a-e97ee46714d0.png">
