### PR TITLE
Remove only tail comment

### DIFF
--- a/unused.rb
+++ b/unused.rb
@@ -125,7 +125,7 @@ class Unused
     items = items_in
     usages = items.map { |f| 0 }
     files.each { |file|
-      lines = File.readlines(file).map {|line| line.gsub(/^[^\/]*\/\/.*/, "")  }
+      lines = File.readlines(file).map {|line| line.gsub(/^([^\/]*)\/\/.*/, '\1')  }
       words = lines.join("\n").split(/\W+/)
       words_arrray = words.group_by { |w| w }.map { |w, ws| [w, ws.length] }.flatten
 


### PR DESCRIPTION
The fix of https://github.com/PaulTaykalo/swift-scripts/pull/14 replace lines with tail comment with empty line. 
I made patch to remove only tail comment from line.

Example: definition `used` has a tail comment.

Original lines

```
=> ["import UIKit\n",
 "\n",
 "class TestView: UIView {\n",
 "  var used = \"\" // should not be ignored\n",
 "  var unused = \"\"\n",
 "\n",
 "  override init(frame: CGRect) {\n",
 "    print(used)\n",
 "    super.init(frame: frame)\n",
 "  }\n",
 "}\n"]
```

Before fix; definition `used` is replaced with `''`

```
=> ["import UIKit\n",
 "\n",
 "class TestView: UIView {\n",
 "\n",
 "  var unused = \"\"\n",
 "\n",
 "  override init(frame: CGRect) {\n",
 "    print(used)\n",
 "    super.init(frame: frame)\n",
 "  }\n",
 "}\n"]
```

After fix

```
=> ["import UIKit\n",
 "\n",
 "class TestView: UIView {\n",
 "  var used = \"\" \n",
 "  var unused = \"\"\n",
 "\n",
 "  override init(frame: CGRect) {\n",
 "    print(used)\n",
 "    super.init(frame: frame)\n",
 "  }\n",
 "}\n"]
```