### PR TITLE
Update of unused.rb

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,23 @@ Starting searching globally it can take a while
 ```
 
 ## Xcode integration
-In order to integrate this to Xcode just add *Custom Build Phase/Run Script*  
-`~/Projects/swift-scripts/unused.rb xcode`  
+To integrate this into Xcode, simply add a "New Run Script Phase" and use the following code:
+```
+file="unused.rb"
+if [ -f "$file" ]
+then
+echo "$file found."
+ruby unused.rb xcode
+else
+echo "unused.rb doesn't exist"
+fi
+```
+### Xcode ~/project/Build Phases:
+<img width="500" alt="Screenshot 2024-02-08 at 12 05 28" src="https://github.com/paulmaxgithub/swift-scripts/assets/45998744/9098f9ce-34b2-4b77-91c2-f7308a9d4365">
+
+### Code Example:
 ![](https://user-images.githubusercontent.com/119268/32348473-88080ed2-c01c-11e7-9de6-762aeb195156.png)
-![](https://user-images.githubusercontent.com/119268/32348476-8af3a700-c01c-11e7-893f-013851568882.png)
+
 
 ## Known issues:
 - Fully text search (no fancy stuff)

--- a/unused.rb
+++ b/unused.rb
@@ -8,7 +8,8 @@ class Item
     @file = file
     @line = line
     @at = at + 1
-    if match = line.match(/(func|let|var|class|enum|struct|protocol)\s+(\w+)/)
+    # typealias was added ⚠️
+    if match = line.match(/(func|let|var|class|enum|struct|protocol|typealias)\s+(\w+)/)
       @type = match.captures[0]
       @name = match.captures[1]
     end
@@ -117,7 +118,6 @@ class Unused
        "Tests/"
      ]
    end 
-
    regexps
  end  
 
@@ -175,15 +175,15 @@ class Unused
 
   def grab_items(file)
     lines = File.readlines(file).map {|line| line.gsub(/^\s*\/\/.*/, "")  }
-    items = lines.each_with_index.select { |line, i| line[/(func|let|var|class|enum|struct|protocol)\s+\w+/] }.map { |line, i| Item.new(file, line, i)}
+    # typealias was added ⚠️
+    items = lines.each_with_index.select { |line, i| line[/(func|let|var|class|enum|struct|protocol|typealias)\s+\w+/] }.map { |line, i| Item.new(file, line, i)}
   end  
 
+  # "CodingKeys" & "@main" & "Previews" for SwiftUI were added ⚠️
   def filter_items(items)
     items.select { |f| 
-      !f.name.start_with?("test") && !f.modifiers.include?("@IBAction") && !f.modifiers.include?("override") && !f.modifiers.include?("@objc") && !f.modifiers.include?("@IBInspectable")
-    }
+      !f.name.start_with?("test") && !f.modifiers.include?("@IBAction") && !f.modifiers.include?("override") && !f.modifiers.include?("@objc") && !f.modifiers.include?("@IBInspectable") && !f.modifiers.include?("@main") && !f.name.include?("CodingKeys") && !f.name.include?("Previews")}
   end
-
 end  
 
 class String
@@ -211,6 +211,5 @@ class String
   def blink;          "\e[5m#{self}\e[25m" end
   def reverse_color;  "\e[7m#{self}\e[27m" end
 end
-
 
 Unused.new.find


### PR DESCRIPTION
It was added:
1. "CodingKeys" to ignore enum (CodingKeys: String, CodingKey)
2. "@main" to ignore all entry point files, such as AppDelegate or application type in SwiftUI implementation
3. "Previews" to ignore all PreviewProvider type structures that present user interfaces in SwiftUI interfaces
4. |typealias| to find unused typealias in code